### PR TITLE
fixing "every hour" cron syntax

### DIFF
--- a/weatherstack.groovy
+++ b/weatherstack.groovy
@@ -112,7 +112,7 @@ metadata  {
                      '0 */10 * ? * * *':'10 minutes',
                      '0 */15 * ? * * *': '15 minutes',
                      '0 */30 * ? * * *':'30 minutes',
-                     '0 0 0 ? * * *':'1 Hour'
+                     '0 0 * ? * * *':'1 Hour'
                     ]
         )
         input(
@@ -124,7 +124,7 @@ metadata  {
                      '0 */10 * ? * * *':'10 minutes',
                      '0 */15 * ? * * *': '15 minutes',
                      '0 */30 * ? * * *':'30 minutes',
-                     '0 0 0 ? * * *':'1 Hour'
+                     '0 0 * ? * * *':'1 Hour'
                      ]
         )
         //logging message config


### PR DESCRIPTION
The former statement `0 0 0 ? * * *` would have gone at 0:00 every day; instead we want `0 0 * ? * * *` to go at the top of every hour (see https://crontab.cronhub.io/ to check my work)